### PR TITLE
Fix pod install error

### DIFF
--- a/ios/RNGetValues.podspec
+++ b/ios/RNGetValues.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNGetValues
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/stevenselcuk/react-native-get-values"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
When doing a pod install after adding this module, got an error:

[!] The `RNGetValues` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.


Easy fix.